### PR TITLE
replaced apostrophe with html character reference on timeQuote

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -17,7 +17,7 @@ var timeQuotes = [
     "time is much more valuable than money",
     "if time were to take on human form, would she be your taskmaster or freedom fighter?",
     "lack of direction, not lack of time, is the problem. we all have twenty-four hour days",
-    "if you spend too much time thinking about a thing, you’ll never get it done",
+    "if you spend too much time thinking about a thing, you&#8217;ll never get it done",
     "the best time to start was last year. failing that, today will do"
 ];
 


### PR DESCRIPTION
There was an issue with displaying on of the timeQuotes due to the apostrophe, so I replaced it with the HTML character reference instead. 

I love this extension by the way!
